### PR TITLE
Update for incorrect reference to Server Farm

### DIFF
--- a/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-preexisting-rg.json
+++ b/samples/csharp_dotnetcore/11.qnamaker/DeploymentTemplates/template-with-preexisting-rg.json
@@ -102,7 +102,7 @@
             "name": "[variables('webAppName')]",
             "properties": {
                 "name": "[variables('webAppName')]",
-                "serverFarmId": "[variables('servicePlanName')]",
+                "serverFarmId": "[resourceId('Microsoft.Web/serverfarms/', variables('servicePlanName'))]",
                 "siteConfig": {
                     "appSettings": [
                         {


### PR DESCRIPTION
serverFarmId was referencing the servicePlanName only and not the actual ServerFarm ID as required.

Fixes #<!-- If this addresses a specific issue, please provide the issue number here -->

## Proposed Changes
<!-- Please discuss the changes you have worked on. What do the changes do; why is this PR needed? -->
<!-- You must demonstrate that the code works. Include screenshots of the code in action -->
<!-- If you are introducing a new sample, make sure that the sample adheres to sample guidelines -->

  - 
  -
  -


## Testing
<!-- If you are adding a new feature to a library, you must include tests for your new code. -->